### PR TITLE
Feature/wezterm role

### DIFF
--- a/molecule/bootstrap/converge.yml
+++ b/molecule/bootstrap/converge.yml
@@ -3,5 +3,5 @@
   hosts: all
   gather_facts: false
   roles:
-    - role: ../../roles/bootstrap
+    - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/bootstrap"
 

--- a/molecule/bootstrap/verify.yml
+++ b/molecule/bootstrap/verify.yml
@@ -1,22 +1,32 @@
 ---
-- name: Verify basic bootstrap
+- name: Verify
   hosts: all
-  gather_facts: false
   tasks:
-    - name: Stat python3 binary
+    - name: Verify Python3 file metadata
       ansible.builtin.stat:
         path: /usr/bin/python3
-      register: py
-    - name: Assert python3 exists and is executable
+        follow: true
+      register: python3
+
+    - name: Assert Python3 exists and is executable
       ansible.builtin.assert:
         that:
-          - py.stat.exists
-          - "((py.stat.mode | int(base=8)) % 8) != 0"
+          - python3.stat.exists
+          - python3.stat.mode is match("^0?755$")
+
     - name: Gather package facts
       ansible.builtin.package_facts:
-    - name: Assert python3 and sudo packages are present
+
+    - name: Assert Python3 and sudo packages are present
       ansible.builtin.assert:
         that:
           - "'python3' in ansible_facts.packages"
-          - "'sudo'     in ansible_facts.packages"
+          - "'sudo' in ansible_facts.packages"
+
+    - name: Assert Python-DNF packages are present
+      ansible.builtin.assert:
+        that:
+         - "'python3-dnf' in ansible_facts.packages"
+         - "'python3-libdnf5' in ansible_facts.packages"
+      when: ansible_facts.pkg_mgr == "dnf5"
 

--- a/molecule/wezterm/converge.yml
+++ b/molecule/wezterm/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  pre_tasks:
+    - name: Install basic dependencies
+      ansible.builtin.import_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/bootstrap"
+      become: false
+
+    - name: Gather facts now that Python3 is installed
+      ansible.builtin.setup:
+  become: true
+  roles:
+    - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/wezterm"
+

--- a/molecule/wezterm/molecule.yml
+++ b/molecule/wezterm/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+provisioner:
+  name: ansible
+
+platforms:
+  - name: fedora-42
+    image: fedora:42
+    pre_build_image: true
+
+  - name: debian-12
+    image: debian:12
+    pre_build_image: true
+

--- a/molecule/wezterm/verify.yml
+++ b/molecule/wezterm/verify.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify Wezterm file metadata
+      ansible.builtin.stat:
+        path: /usr/bin/wezterm
+      register: wezterm
+
+    - name: Assert WezTerm is present and executable
+      ansible.builtin.assert:
+        that:
+          - wezterm.stat.exists
+          - wezterm.stat.mode is match("^0?755$")
+
+    - name: Check WezTerm can report its version
+      ansible.builtin.command: wezterm --version
+      register: wezterm_version
+      changed_when: false
+
+    - name: Assert version command succeeded
+      ansible.builtin.assert:
+        that:
+          - wezterm_version.rc == 0
+          - wezterm_version.stdout is search("wezterm")
+

--- a/roles/wezterm/handlers/main.yml
+++ b/roles/wezterm/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: refresh dnf cache
+  ansible.builtin.dnf:
+    update_cache: true
+
+- name: refresh apt cache
+  ansible.builtin.apt:
+    update_cache: true
+

--- a/roles/wezterm/tasks/debian.yml
+++ b/roles/wezterm/tasks/debian.yml
@@ -1,0 +1,22 @@
+---
+# Debian 12
+- name: Add Wezterm repository key
+  ansible.builtin.get_url:
+    url: https://apt.fury.io/wez/gpg.key
+    dest: /usr/share/keyrings/wezterm-fury.gpg
+    mode: 644
+
+- name: Add Wezterm APT repository
+  ansible.builtin.apt_repository:
+    filename: wezterm
+    repo: deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg trusted=yes] https://apt.fury.io/wez/ * *
+    update_cache: false # let the handler do it
+  notify: refresh apt cache
+
+- name: Flush queued handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Install Wezterm
+  ansible.builtin.apt:
+    name: wezterm-nightly
+

--- a/roles/wezterm/tasks/main.yml
+++ b/roles/wezterm/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Load OS-family specific tasks
+  ansible.builtin.include_tasks:
+    file: "{{ ansible_facts.os_family | lower }}.yml"
+

--- a/roles/wezterm/tasks/redhat.yml
+++ b/roles/wezterm/tasks/redhat.yml
@@ -1,0 +1,14 @@
+---
+# Fedora 42
+- name: Enable official COPR for Wezterm
+  community.general.copr:
+    name: wezfurlong/wezterm-nightly
+  notify: refresh dnf cache
+
+- name: Flush queued handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Install Wezterm
+  ansible.builtin.dnf:
+    name: wezterm
+


### PR DESCRIPTION
# Overview
Closes #8

# What’s inside
<!-- Bullet-point summary of key changes -->
- Add a new Wezterm role
- Streamline `verify.yml` in all existing roles

# Motivation & Context
This role aims to install the [Wezterm](https://wezterm.org) terminal emulator.

# Implementation notes
For now, this role only works for:
- Fedora 42
- Debian 12