### PR TITLE
chore: clean up Molecule development workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ PYTHON ?= python3
 VENV ?= .venv
 VENV_BIN := $(VENV)/bin
 COLLECTIONS_PATH ?= .ansible/collections
+FEDORA_VERSION ?= 44
+DEBIAN_VERSION ?= 13
 
 export PATH := $(abspath $(VENV_BIN)):$(PATH)
+export FEDORA_VERSION
+export DEBIAN_VERSION
 
 .PHONY: install
 install: ## Create/update the local virtual environment and install dependencies.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ make test-role ROLE=bootstrap
 make test-role ROLE=wezterm
 ```
 
+Molecule tests use Fedora and Debian container versions defined in the
+Makefile. Override them when testing a newer or older target:
+
+```shell
+FEDORA_VERSION=45 make test-role ROLE=bootstrap
+DEBIAN_VERSION=13 make test-role ROLE=wezterm
+```
+
 ## Dependency Model
 
 There are three dependency layers:

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -25,8 +25,5 @@ Molecule development workflow.
   `~/.ansible`, if any exist.
 - Review useful material from `feature/terminal-playbook`.
 - Review and clean the WIP `feature/fish-role`.
-- Replace deprecated `ansible.builtin.apt_repository` usage in the WezTerm
-  Debian tasks.
-- Reduce Molecule warning noise from named scenarios and missing optional
-  dependency/cleanup files.
+- Reduce Molecule warning noise from named scenarios.
 - Add top-level playbooks after the local development workflow is reliable.

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -8,6 +8,7 @@ Molecule development workflow.
 - Local Python tooling is installed in `.venv`.
 - Ansible Galaxy collections are installed in `.ansible/collections`.
 - Podman is the default Molecule driver.
+- Molecule Fedora and Debian container versions are defined in the Makefile.
 - Ansible Navigator and Ansible Builder are not part of the default workflow.
 - `pipx` can stay installed globally, but it is not used by this project.
 
@@ -25,5 +26,4 @@ Molecule development workflow.
   `~/.ansible`, if any exist.
 - Review useful material from `feature/terminal-playbook`.
 - Review and clean the WIP `feature/fish-role`.
-- Reduce Molecule warning noise from named scenarios.
 - Add top-level playbooks after the local development workflow is reliable.

--- a/molecule/bootstrap/molecule.yml
+++ b/molecule/bootstrap/molecule.yml
@@ -9,10 +9,9 @@ provisioner:
   name: ansible
 
 platforms:
-  - name: fedora-42
-    image: fedora:42
+  - name: fedora-${FEDORA_VERSION:-44}
+    image: fedora:${FEDORA_VERSION:-44}
     pre_build_image: true
-  - name: debian-12
-    image: debian:12
+  - name: debian-${DEBIAN_VERSION:-13}
+    image: debian:${DEBIAN_VERSION:-13}
     pre_build_image: true
-

--- a/molecule/bootstrap/molecule.yml
+++ b/molecule/bootstrap/molecule.yml
@@ -1,12 +1,22 @@
 ---
 dependency:
   name: galaxy
+  enabled: false
 
 driver:
   name: podman
 
 provisioner:
   name: ansible
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
 platforms:
   - name: fedora-${FEDORA_VERSION:-44}

--- a/molecule/wezterm/molecule.yml
+++ b/molecule/wezterm/molecule.yml
@@ -1,12 +1,22 @@
 ---
 dependency:
   name: galaxy
+  enabled: false
 
 driver:
   name: podman
 
 provisioner:
   name: ansible
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
 platforms:
   - name: fedora-${FEDORA_VERSION:-44}

--- a/molecule/wezterm/molecule.yml
+++ b/molecule/wezterm/molecule.yml
@@ -9,11 +9,10 @@ provisioner:
   name: ansible
 
 platforms:
-  - name: fedora-42
-    image: fedora:42
+  - name: fedora-${FEDORA_VERSION:-44}
+    image: fedora:${FEDORA_VERSION:-44}
     pre_build_image: true
 
-  - name: debian-12
-    image: debian:12
+  - name: debian-${DEBIAN_VERSION:-13}
+    image: debian:${DEBIAN_VERSION:-13}
     pre_build_image: true
-

--- a/roles/wezterm/tasks/debian.yml
+++ b/roles/wezterm/tasks/debian.yml
@@ -1,16 +1,14 @@
 ---
-# Debian 12
-- name: Add Wezterm repository key
-  ansible.builtin.get_url:
-    url: https://apt.fury.io/wez/gpg.key
-    dest: /usr/share/keyrings/wezterm-fury.gpg
-    mode: 644
-
 - name: Add Wezterm APT repository
-  ansible.builtin.apt_repository:
-    filename: wezterm
-    repo: deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg trusted=yes] https://apt.fury.io/wez/ * *
-    update_cache: false # let the handler do it
+  ansible.builtin.deb822_repository:
+    name: wezterm
+    types: deb
+    uris: https://apt.fury.io/wez/
+    suites: "*"
+    components: "*"
+    signed_by: https://apt.fury.io/wez/gpg.key
+    trusted: true
+    install_python_debian: true
   notify: refresh apt cache
 
 - name: Flush queued handlers
@@ -19,4 +17,3 @@
 - name: Install Wezterm
   ansible.builtin.apt:
     name: wezterm-nightly
-

--- a/roles/wezterm/tasks/redhat.yml
+++ b/roles/wezterm/tasks/redhat.yml
@@ -1,5 +1,4 @@
 ---
-# Fedora 42
 - name: Enable official COPR for Wezterm
   community.general.copr:
     name: wezfurlong/wezterm-nightly
@@ -11,4 +10,3 @@
 - name: Install Wezterm
   ansible.builtin.dnf:
     name: wezterm
-


### PR DESCRIPTION
## Summary

- Centralize Molecule Fedora/Debian target versions in the Makefile.
- Update default Molecule targets to Fedora 44 and Debian 13.
- Replace deprecated WezTerm Debian repository setup with `deb822_repository`.
- Trim Molecule test sequences while preserving idempotence.
- Document Molecule platform overrides and update the cleanup plan.

## Linked issue

Closes #12 

## Verification

- [x] `make doctor`
- [x] `make lint`
- [x] `make test-role ROLE=bootstrap`
- [x] `make test-role ROLE=wezterm`

## Notes

The remaining Podman schema warning appears to come from the installed Molecule Podman plugin rather than this repo’s scenario configuration.

Larger follow-up work remains separate: reviewing `feature/fish-role`, reviewing `feature/terminal-playbook`, and adding top-level playbooks.