### PR TITLE
docs: document project intent and role design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+## Project Intent
+
+ProvisionMe is a personal Ansible workspace for rebuilding and maintaining
+working environments from setup notes. Optimize for the owner's machines first,
+especially the Fedora workstation. Debian support is useful where practical,
+including for possible home lab use.
+
+## Working Style
+
+- Prefer small, reviewable changes.
+- Inspect relevant files before proposing structure changes.
+- When building or changing Ansible roles, explain the Ansible concepts and
+  tradeoffs behind the implementation so the owner can learn from the work.
+- Preserve the current simple local workflow: project `.venv`, local
+  `.ansible/collections`, Makefile targets, and Podman-backed Molecule tests.
+- Keep roles composable and playbooks focused on coordinating complete
+  environments.
+- Treat a role as one independently managed capability, not necessarily one
+  package or one command.
+- Avoid broad rewrites unless explicitly requested.
+
+## Role Guidance
+
+Roles may represent tools, runtimes, language environments, machine baselines,
+or shared setup concerns.
+
+A role should usually have at least one reason to exist independently:
+
+- non-trivial install logic
+- configuration files or templates
+- operating-system specific behavior
+- variables or defaults worth exposing
+- Molecule coverage
+- reuse across more than one playbook
+
+Small baseline packages should usually live in a broader role instead of getting
+one role each.
+
+## Documentation And Future Work
+
+Use `docs/design-notes.md` for stable project intent and design decisions.
+
+Use `docs/development-plan.md` for cleanup work, technical debt, follow-up
+tasks, and useful ideas found during a session.
+
+Near the end of each session, review what was learned or deferred. If there are
+concrete follow-ups worth preserving, update `docs/development-plan.md` instead
+of leaving them only in chat.
+
+## Verification
+
+When changing Ansible roles or Molecule scenarios, run the narrowest useful
+checks first, such as:
+
+```shell
+make lint
+make test-role ROLE=<role>
+```
+
+If sandboxing or local host constraints make verification unreliable, report the
+exact command and failure instead of treating the result as authoritative.
+
+Prefer Molecule for role behavior tests. Use direct Python tests for standalone
+Python code or pure logic, such as custom Ansible modules, filter plugins,
+inventory scripts, helper scripts, or parsing and normalization functions.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The first priority is keeping the local development workflow simple and
 repeatable. This project uses a local Python virtual environment for Ansible
 tooling and Podman-backed Molecule scenarios for role tests.
 
+See [docs/design-notes.md](docs/design-notes.md) for the project intent, role
+model, playbook model, and current design choices such as using WezTerm nightly.
+
 ## Requirements
 
 Install these system tools before setting up the project:

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -1,0 +1,77 @@
+# Design Notes
+
+ProvisionMe exists to turn manual setup notes into repeatable Ansible
+automation. When I install a tool, runtime, or development setup on my laptop, I
+often note the commands I ran and the settings I chose. This repository is where
+those notes become roles and playbooks, so a future machine can be rebuilt
+without rediscovering the same steps.
+
+The main target is my Fedora workstation. Debian is also worth supporting where
+practical because some roles and playbooks may later be useful on Debian-based
+machines, including a home lab.
+
+## Roles
+
+Roles should represent independently managed capabilities.
+
+Often that means one role per tool, such as `wezterm` or `fish`. That works well
+when the tool has its own installation source, configuration, operating-system
+differences, defaults, or tests.
+
+The model is broader than one role per tool. A role can also represent a
+runtime, language environment, machine baseline, or shared setup concern. For
+example, roles such as `python`, `php`, `node`, `bootstrap`, `fonts`, or
+`dotfiles` can make sense if they own a coherent part of the machine setup.
+
+Small packages that are only baseline dependencies should usually live in a
+broader role instead of becoming one role each.
+
+## Playbooks
+
+Playbooks coordinate roles into complete working environments.
+
+Examples of useful playbooks might include:
+
+- a workstation playbook for the main laptop setup
+- a PHP development playbook
+- a TypeScript or Node development playbook
+- a home lab playbook
+
+The roles should stay composable. The playbooks should express the intent:
+which environment is being built, which capabilities are needed, and in what
+order they should be applied.
+
+## Dotfiles
+
+The `dotmaster` repository may eventually become part of this workflow. The
+likely shape is a dedicated `dotfiles` or `dotmaster` role, or a specific
+playbook step that applies personal configuration after the relevant tools are
+installed.
+
+Tool roles should generally install and prepare tools. Dotfile management should
+stay centralized unless a tool has configuration that clearly belongs inside the
+role itself.
+
+## WezTerm Nightly
+
+The WezTerm role intentionally installs the nightly package. The primary target
+is a Fedora workstation, where newer desktop and terminal tooling is acceptable,
+and the stable WezTerm release can lag behind current development.
+
+If this role later needs to support more conservative machines, nightly versus
+stable should become a role variable instead of an implicit policy.
+
+## Testing
+
+Molecule is the default way to test role behavior. It is the right tool when the
+test needs a target system, package manager, service manager, repository, file
+ownership, command, or operating-system difference.
+
+Direct Python tests are useful when there is standalone Python code or pure
+logic to verify without provisioning a machine. Examples include custom Ansible
+modules, filter plugins, inventory scripts, helper scripts, generated config
+validation, or parsing and normalization functions.
+
+Python tests should not replace Molecule for behavior that only proves itself on
+a real target container, such as package installation, repository setup, shell
+changes, idempotence, or Fedora versus Debian task behavior.


### PR DESCRIPTION
## Summary

- Add `docs/design-notes.md` with the project intent, role model, playbook model, `dotmaster` direction, WezTerm nightly rationale, and testing strategy.
- Add `AGENTS.md` with project-specific guidance for future assistant sessions.
- Link the design notes from `README.md`.

## Linked issue

Closes #14 

## Verification

- [x] `make doctor`
- [x] `make lint`
- [x] `make test-role ROLE=<role>`

## Notes

Docs-only change. No Ansible role, playbook, or Molecule behavior changed, so role-specific verification was not run.