### PR TITLE
feat: add fish role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install: ## Create/update the local virtual environment and install dependencies
 
 .PHONY: lint
 lint: ## Run Ansible lint.
-	@ansible-lint .
+	@ansible-lint roles molecule
 
 .PHONY: test
 test: ## Run all Molecule scenarios.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ make doctor
 make lint
 make test
 make test-role ROLE=bootstrap
+make test-role ROLE=fish
 make test-role ROLE=wezterm
 ```
 
@@ -79,6 +80,7 @@ Makefile. Override them when testing a newer or older target:
 
 ```shell
 FEDORA_VERSION=45 make test-role ROLE=bootstrap
+FEDORA_VERSION=45 make test-role ROLE=fish
 DEBIAN_VERSION=13 make test-role ROLE=wezterm
 ```
 

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -18,12 +18,14 @@ Molecule development workflow.
 - `make install` creates/updates the local project environment.
 - `make lint` passes with 0 failures and 0 warnings.
 - `make test-role ROLE=bootstrap` passes on the host.
+- `make test-role ROLE=fish` passes on the host.
 - `make test-role ROLE=wezterm` passes on the host.
+- `make test` passes on the host.
 
 ## Remaining Work
 
 - Review and manually remove obsolete project-related collections from
   `~/.ansible`, if any exist.
 - Review useful material from `feature/terminal-playbook`.
-- Review and clean the WIP `feature/fish-role`.
+- Delete the old WIP `feature/fish-role` branch after the new Fish role lands.
 - Add top-level playbooks after the local development workflow is reliable.

--- a/molecule/bootstrap/converge.yml
+++ b/molecule/bootstrap/converge.yml
@@ -3,5 +3,4 @@
   hosts: all
   gather_facts: false
   roles:
-    - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/bootstrap"
-
+    - role: bootstrap

--- a/molecule/bootstrap/molecule.yml
+++ b/molecule/bootstrap/molecule.yml
@@ -8,6 +8,9 @@ driver:
 
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
 
 scenario:
   test_sequence:

--- a/molecule/bootstrap/verify.yml
+++ b/molecule/bootstrap/verify.yml
@@ -26,7 +26,6 @@
     - name: Assert Python-DNF packages are present
       ansible.builtin.assert:
         that:
-         - "'python3-dnf' in ansible_facts.packages"
-         - "'python3-libdnf5' in ansible_facts.packages"
+          - "'python3-dnf' in ansible_facts.packages"
+          - "'python3-libdnf5' in ansible_facts.packages"
       when: ansible_facts.pkg_mgr == "dnf5"
-

--- a/molecule/fish/converge.yml
+++ b/molecule/fish/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  pre_tasks:
+    - name: Install basic dependencies
+      ansible.builtin.import_role:
+        name: bootstrap
+      become: false
+
+    - name: Gather facts now that Python3 is installed
+      ansible.builtin.setup:
+  become: true
+  roles:
+    - role: fish
+      vars:
+        fish_manage_login_shell: true
+        fish_users:
+          - root

--- a/molecule/fish/molecule.yml
+++ b/molecule/fish/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+
+driver:
+  name: podman
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
+
+platforms:
+  - name: fedora-${FEDORA_VERSION:-44}
+    image: fedora:${FEDORA_VERSION:-44}
+    pre_build_image: true
+
+  - name: debian-${DEBIAN_VERSION:-13}
+    image: debian:${DEBIAN_VERSION:-13}
+    pre_build_image: true

--- a/molecule/fish/verify.yml
+++ b/molecule/fish/verify.yml
@@ -1,0 +1,59 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Discover Fish binary path
+      ansible.builtin.command:
+        argv:
+          - fish
+          - --command
+          - status fish-path
+      register: fish_binary
+      changed_when: false
+
+    - name: Verify Fish file metadata
+      ansible.builtin.stat:
+        path: "{{ fish_binary.stdout }}"
+        follow: true
+      register: fish
+
+    - name: Assert Fish is present and executable
+      ansible.builtin.assert:
+        that:
+          - fish.stat.exists
+          - fish.stat.mode is match("^0?755$")
+
+    - name: Check Fish can report its version
+      ansible.builtin.command:
+        argv:
+          - fish
+          - --version
+      register: fish_version
+      changed_when: false
+
+    - name: Assert version command succeeded
+      ansible.builtin.assert:
+        that:
+          - fish_version.rc == 0
+          - fish_version.stdout is search("fish")
+
+    - name: Check Fish is listed in /etc/shells
+      ansible.builtin.command:
+        argv:
+          - grep
+          - --fixed-strings
+          - --line-regexp
+          - "{{ fish_binary.stdout }}"
+          - /etc/shells
+      changed_when: false
+
+    - name: Retrieve root account information
+      ansible.builtin.getent:
+        database: passwd
+        key: root
+
+    - name: Assert Fish is root's login shell
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.getent_passwd.root[-1] == fish_binary.stdout

--- a/molecule/wezterm/converge.yml
+++ b/molecule/wezterm/converge.yml
@@ -5,12 +5,11 @@
   pre_tasks:
     - name: Install basic dependencies
       ansible.builtin.import_role:
-        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/bootstrap"
+        name: bootstrap
       become: false
 
     - name: Gather facts now that Python3 is installed
       ansible.builtin.setup:
   become: true
   roles:
-    - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/wezterm"
-
+    - role: wezterm

--- a/molecule/wezterm/molecule.yml
+++ b/molecule/wezterm/molecule.yml
@@ -8,6 +8,9 @@ driver:
 
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
 
 scenario:
   test_sequence:

--- a/molecule/wezterm/verify.yml
+++ b/molecule/wezterm/verify.yml
@@ -15,7 +15,8 @@
           - wezterm.stat.mode is match("^0?755$")
 
     - name: Check WezTerm can report its version
-      ansible.builtin.command: wezterm --version
+      ansible.builtin.command:
+        cmd: wezterm --version
       register: wezterm_version
       changed_when: false
 
@@ -24,4 +25,3 @@
         that:
           - wezterm_version.rc == 0
           - wezterm_version.stdout is search("wezterm")
-

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -6,26 +6,27 @@
       elif command -v apt-get >/dev/null 2>&1; then echo apt;
       else echo unknown; fi
     '
-  register: package_manager
+  register: bootstrap_package_manager
   changed_when: false
 
 - name: Check for Python3 binary
   ansible.builtin.raw: test -x /usr/bin/python3
-  register: python3_check
+  register: bootstrap_python3_check
   failed_when: false
   changed_when: false
 
 - name: Install Python3 if missing
   ansible.builtin.raw: >
    /bin/sh -c '
-      if [ "{{ package_manager.stdout | trim }}" = "dnf" ]; then
+      if [ "{{ bootstrap_package_manager.stdout | trim }}" = "dnf" ]; then
         dnf -y install python3 python3-dnf python3-libdnf5;
-      elif [ "{{ package_manager.stdout | trim }}" = "apt" ]; then
+      elif [ "{{ bootstrap_package_manager.stdout | trim }}" = "apt" ]; then
         DEBIAN_FRONTEND=noninteractive apt-get update -y &&
         apt-get install -y python3;
       fi
     '
-  when: python3_check.rc != 0
+  changed_when: true
+  when: bootstrap_python3_check.rc != 0
 
 # Shoud reset SSH here ?
 
@@ -36,4 +37,3 @@
   ansible.builtin.package:
     name: sudo
     state: present
-

--- a/roles/fish/defaults/main.yml
+++ b/roles/fish/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+fish_manage_login_shell: false
+fish_users:
+  - "{{ ansible_user_id }}"

--- a/roles/fish/tasks/debian.yml
+++ b/roles/fish/tasks/debian.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Fish
+  ansible.builtin.apt:
+    name: fish
+    state: present

--- a/roles/fish/tasks/main.yml
+++ b/roles/fish/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Abort if the OS family is unsupported
+  ansible.builtin.fail:
+    msg: >
+      {{ ansible_distribution }} {{ ansible_distribution_version }}
+      is not supported by the fish role. Supported OS families: Debian, RedHat.
+  when: ansible_facts.os_family | lower not in ['debian', 'redhat']
+
+- name: Install Fish on the current OS family
+  ansible.builtin.include_tasks:
+    file: "{{ ansible_facts.os_family | lower }}.yml"
+
+- name: Discover Fish binary path
+  ansible.builtin.command:
+    argv:
+      - fish
+      - --command
+      - status fish-path
+  register: fish_binary
+  changed_when: false
+
+- name: Run Fish post-install tasks
+  ansible.builtin.include_tasks:
+    file: post_install.yml

--- a/roles/fish/tasks/post_install.yml
+++ b/roles/fish/tasks/post_install.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure Fish is listed in /etc/shells
+  ansible.builtin.lineinfile:
+    path: /etc/shells
+    line: "{{ fish_binary.stdout }}"
+    state: present
+
+- name: Ensure Fish is the login shell
+  ansible.builtin.user:
+    name: "{{ item }}"
+    shell: "{{ fish_binary.stdout }}"
+    state: present
+  loop: "{{ fish_users }}"
+  when: fish_manage_login_shell | bool

--- a/roles/fish/tasks/redhat.yml
+++ b/roles/fish/tasks/redhat.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Fish
+  ansible.builtin.dnf:
+    name: fish
+    state: present

--- a/roles/wezterm/handlers/main.yml
+++ b/roles/wezterm/handlers/main.yml
@@ -1,9 +1,8 @@
 ---
-- name: refresh dnf cache
+- name: Refresh dnf cache
   ansible.builtin.dnf:
     update_cache: true
 
-- name: refresh apt cache
+- name: Refresh apt cache
   ansible.builtin.apt:
     update_cache: true
-

--- a/roles/wezterm/tasks/debian.yml
+++ b/roles/wezterm/tasks/debian.yml
@@ -9,7 +9,7 @@
     signed_by: https://apt.fury.io/wez/gpg.key
     trusted: true
     install_python_debian: true
-  notify: refresh apt cache
+  notify: Refresh apt cache
 
 - name: Flush queued handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/wezterm/tasks/main.yml
+++ b/roles/wezterm/tasks/main.yml
@@ -2,4 +2,3 @@
 - name: Load OS-family specific tasks
   ansible.builtin.include_tasks:
     file: "{{ ansible_facts.os_family | lower }}.yml"
-

--- a/roles/wezterm/tasks/redhat.yml
+++ b/roles/wezterm/tasks/redhat.yml
@@ -2,7 +2,7 @@
 - name: Enable official COPR for Wezterm
   community.general.copr:
     name: wezfurlong/wezterm-nightly
-  notify: refresh dnf cache
+  notify: Refresh dnf cache
 
 - name: Flush queued handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
## Summary

- Add a Fish role for Fedora and Debian targets.
- Register the discovered Fish binary in `/etc/shells` and optionally set configured users' login shell.
- Add Molecule coverage for the Fish role.
- Tighten lint and Molecule role resolution so local roles are checked consistently.

## Linked issue

Closes #16 

## Verification

- [x] `make doctor`
- [x] `make lint`
- [x] `make test-role ROLE=fish`
- [x] `make test`

## Notes

Fisher bootstrap and Fish plugins are intentionally left to dotmaster. ProvisionMe only owns the system-level shell setup here.